### PR TITLE
Upgrade tomcat 9

### DIFF
--- a/images/authoring/tomcat/Dockerfile
+++ b/images/authoring/tomcat/Dockerfile
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-FROM tomcat:8-jdk11-openjdk-slim as main
+FROM tomcat:9-jdk11-openjdk-slim as main
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/delivery/tomcat/Dockerfile
+++ b/images/delivery/tomcat/Dockerfile
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-FROM tomcat:8-jdk11-openjdk-slim as main
+FROM tomcat:9-jdk11-openjdk-slim as main
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/profile/Dockerfile
+++ b/images/profile/Dockerfile
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-FROM tomcat:8-jdk11-openjdk-slim as main
+FROM tomcat:9-jdk11-openjdk-slim as main
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5107

```
$ ./version.sh
Using CATALINA_BASE:   /usr/local/tomcat
Using CATALINA_HOME:   /usr/local/tomcat
Using CATALINA_TMPDIR: /usr/local/tomcat/temp
Using JRE_HOME:        /usr/local/openjdk-11
Using CLASSPATH:       /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
Using CATALINA_OPTS:    -Dtomcat.host= -Dtomcat.http.port=   -Dtomcat.https.port= -Dtomcat.ajp.port=   -Dtomcat.debug.port= -Dcrafter.home=   -Dcrafter.bin.dir= -Dcrafter.data.dir= -Dcrafter.logs.dir=   -Dcatalina.logs= -Dapplication.logs= -Djava.net.preferIPv4Stack=true 	-Dgrape.root=
NOTE: Picked up JDK_JAVA_OPTIONS:  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
Server version: Apache Tomcat/9.0.55
Server built:   Nov 10 2021 08:26:45 UTC
Server number:  9.0.55.0
OS Name:        Linux
OS Version:     5.8.0-55-generic
Architecture:   amd64
JVM Version:    11.0.13+8
JVM Vendor:     Oracle Corporation
```